### PR TITLE
Adiciona Método de entrada de dados

### DIFF
--- a/sicp/newton.lisp
+++ b/sicp/newton.lisp
@@ -39,6 +39,13 @@
 (defun range (a b)
   (loop for x from a to b collect x))
 
+(defun range-Python (&rest lista)
+  (cond ((= 3 (length lista)) (range :min (nth 0 lista) :max (nth 1 lista) :step (nth 2 lista)))
+	((= 2 (length lista)) (range :min (nth 0 lista) :max (nth 1 lista)))
+	((= 1 (length lista))  (range :max (nth 0 lista)))
+	(t (error "Número invalido de argumentos"))))
+
+
 ;; to test
 ;; http://malisper.me/2015/08/19/debugging-lisp-part-5-miscellaneous/
 


### PR DESCRIPTION
Supõe a existência de uma função Range já definida com parâmetros (&key (min 0) max (step 1))-> (Complemento do Range do Tales)

Evita o usuário ter que digitar (range :min 10 :max 30 : step 3), ao invés disso, (range-python 10 30 3)

Segue documentação Python no seguinte sentido:
Se são dados três argumentos : Considera-se que são o start, o end e o step, respectivamente.
Se são dados 2 argumentos : Considera-se que são o start e o end, e tomamos o step padrão(que é 1).
Se é dado 1 argumento: Considera-se que é o end, e tomamos o start padrão(0) e o step padrão (1).
Se é dado qualquer outro número de argumentos, envia-se uma mensagem de erro.