### PR TITLE
Talesrands patch 1

### DIFF
--- a/paip/eliza.lisp
+++ b/paip/eliza.lisp
@@ -157,7 +157,7 @@
   "Respond to user input using pattern matching rules."
   (loop
     (print 'eliza-prompt>)
-    (write (flatten (use-eliza-rules (read) :rules rules :preproc preproc)) :pretty t)))
+    (write (flatten (use-eliza-rules (string2list (read-line)) :rules rules :preproc preproc)) :pretty t)))
 
 
 

--- a/paip/packages.lisp
+++ b/paip/packages.lisp
@@ -14,7 +14,8 @@
    #:debug-off
    #:dbg-indent
    #:starts-with
-   #:flatten))
+   #:flatten
+   #:string2list))
 
 (defpackage :chapter-1
   (:use :utils :cl)

--- a/paip/utils.lisp
+++ b/paip/utils.lisp
@@ -138,3 +138,11 @@
     (fresh-line *debug-io*)
     (dotimes (i indent) (princ "  " *debug-io*))
     (apply #'format *debug-io* format-string args)))
+
+
+(defun string2list (str &optional (start 0) (alist nil))
+   (let ((pos (nth-value 1 (read-from-string str t nil :start start)))
+         (strn (read-from-string str t nil :start start)))
+   (if (< pos (length str))
+       (string2list str pos (append alist (list strn)))
+       (append alist (list strn)))))


### PR DESCRIPTION
Permite que o Eliza entenda o input do usuário mesmo sem o uso dos parênteses. Para tal, criei uma função a que chamei ```string2list```. É uma parte do exercício 5.5 do PAIP, mas não resolve a coisa das pontuações (continua dando pau com , ou . ).