### PR TITLE
Adiciona um interpretador interativo

### DIFF
--- a/paip/eliza.lisp
+++ b/paip/eliza.lisp
@@ -164,3 +164,18 @@
        (format t "~{~A ~}" answer)
        (if (member 'exit answer :test #'utils:eql-by-name-if-symbol)
 	   (return-from out))))))
+		   
+(defun eliza (rules preproc)
+  "Respond to user input using pattern matching rules."
+  (interactive-interpreter
+   :read #'read-line 
+   :eval #'(lambda(x) 
+	     (flatten (use-eliza-rules (string->list x) :rules rules 
+				       :preproc preproc)))
+   :print-prompt #'(lambda(x) 
+		     (format t "~A" x))
+   :print-eval #'(lambda(x) 
+		   (format t "~{~A ~}~%" x))
+   :exit #'(lambda(x y) 
+	     (member x y :test #'utils:eql-by-name-if-symbol))
+   :prompt "eliza> "))

--- a/paip/packages.lisp
+++ b/paip/packages.lisp
@@ -16,7 +16,8 @@
    #:starts-with
    #:flatten
    #:string->list
-   #:eql-by-name-if-symbol))
+   #:eql-by-name-if-symbol
+   #:interactive-interpreter))
 
 (defpackage :chapter-1
   (:use :utils :cl)

--- a/paip/utils.lisp
+++ b/paip/utils.lisp
@@ -146,3 +146,58 @@
     (if (and strn (<= pos (length str)))
 	(string->list str pos (cons strn alist))
 	(reverse alist))))
+
+(defun interactive-interpreter (prompt transformer)
+  (loop 
+     (print prompt)
+     (print (funcall transformer (read-line)))))
+
+(defun interactive-interpreter (prompt transformer)
+  (loop
+    (handler-case
+	(progn
+	  (if (stringp prompt)
+	      (print prompt)
+	      (funcall prompt))
+	  (force-output)
+	  (print (funcall transformer (read-line))))
+      (error (condition)
+        (format t "~&;; Error ~a ignored, back to top level." condition)))))
+
+(defun interactive-interpreter (&key (read #'read) (eval #'eval)
+				  (print-prompt #'print) (prompt "> ")
+				  (print-eval #'print))
+  (loop
+     (handler-case
+	 (progn
+	   (if (stringp prompt)
+	       (funcall print-prompt prompt)
+	       (funcall prompt))
+	   (force-output)
+	   (funcall print-eval (funcall eval (funcall read))))
+       (error (condition)
+	 (format t "~&;; Error ~a ignored, back to top level." condition)))))
+
+(defun interactive-interpreter (&key (read #'read) (eval #'eval)
+				  (print-prompt #'print) (prompt "> ")
+				  (print-eval #'print) (exit #'equal)
+				  (exit-symbol 'exit))
+  (block out 			  
+    (loop
+       (handler-case
+	   (progn
+	     (if (stringp prompt)
+		 (funcall print-prompt prompt)
+		 (funcall prompt))
+	     (force-output)
+	     (let* ((value 
+		     (funcall eval (funcall read))))
+	       (funcall print-eval value)
+	       (if (funcall exit exit-symbol value)
+		   (return-from out))))
+       (error (condition)
+	      (format t "~&;; Error ~a ignored, back to top level." condition))))))
+     
+(defun prompt-generator (&optional (num 0) (ctl-string "[~d] "))
+  "Return a function that prints prompts like [1], [2], etc."
+  #'(lambda () (format t ctl-string (incf num))))


### PR DESCRIPTION
Adiciona um interpretador interativo. Foram feitas 4 versões, cada uma adicionando alguma funcionalidade. Além disso, usamos o nosso interpretador para o ELIZA. Uma das funcionalidades adicionadas na última versão é adicionar a saída do ELIZA, usando a mesma ideia que usávamos anteriormente. (member 'exit answer...).