### PR TITLE
Adiciona Framework de Casos de Teste

### DIFF
--- a/paip/packages.lisp
+++ b/paip/packages.lisp
@@ -77,9 +77,11 @@
    #:is
    #:prepend
    #:breadth-first-search
-   #:finite-binary-tree))
+   #:finite-binary-tree
+   #:diff
+   #:best-first-search))
 
-(defpackage :testcases
+(defpackage :testcases-framework
   (:use :utils :cl :search :eliza :eliza-test)
   (:export
    #:deftest
@@ -89,7 +91,7 @@
    #:report-result))
 
 (defpackage :test-search
-  (:use :utils :cl :search :testcases))
+  (:use :utils :cl :search :testcases-framework))
   
 (defpackage :test-pattern
-  (:use :utils :cl :pattern :testcases))
+  (:use :utils :cl :pattern :testcases-framework))

--- a/paip/packages.lisp
+++ b/paip/packages.lisp
@@ -69,4 +69,24 @@
   (:use :cl :utils :eliza :pattern))
 
 (defpackage :search
-  (:use :cl :utils))
+  (:use :cl :utils)
+  (:export
+   #:tree-search
+   #:depth-first-search
+   #:binary-tree
+   #:is
+   #:prepend
+   #:breadth-first-search
+   #:finite-binary-tree))
+
+(defpackage :testcases
+  (:use :utils :cl :search :eliza :eliza-test)
+  (:export
+   #:deftest
+   #:combine-results
+   #:with-gensyms
+   #:check
+   #:report-result))
+
+(defpackage :test-search
+  (:use :utils :cl :search :testcases))

--- a/paip/paip.asd
+++ b/paip/paip.asd
@@ -18,5 +18,8 @@
 	       (:file "eliza"            :depends-on ("pattern"))
 	       (:file "eliza-english"    :depends-on ("eliza"))
 	       (:file "eliza-portuguese" :depends-on ("eliza"))
-	       (:file "search"           :depends-on ("utils"))))
+	       (:file "search"           :depends-on ("utils"))
+	       (:file "testcases"        :depends-on ("utils"))
+	       (:file "test-search"      :depends-on ("testcases"))))
+
 

--- a/paip/paip.asd
+++ b/paip/paip.asd
@@ -6,7 +6,7 @@
 
 (asdf:defsystem #:paip
   :serial t
-  :components ((:file "packages") 
+  :components ((:file "packages")
 	       (:file "utils"            :depends-on ("packages"))
 	       (:file "sentence-1"       :depends-on ("utils"))
 	       (:file "sentence-2"       :depends-on ("utils"))
@@ -19,7 +19,8 @@
 	       (:file "eliza-english"    :depends-on ("eliza"))
 	       (:file "eliza-portuguese" :depends-on ("eliza"))
 	       (:file "search"           :depends-on ("utils"))
-	       (:file "testcases"        :depends-on ("utils"))
-	       (:file "test-search"      :depends-on ("testcases"))))
+	       (:file "testcases-framework" :depends-on ("utils"))
+	       (:file "test-search"      :depends-on ("search"))
+	       (:file "test-pattern"     :depends-on ("pattern"))))
 
 

--- a/paip/search.lisp
+++ b/paip/search.lisp
@@ -8,13 +8,13 @@
 (defun tree-search (states goal-p successors combiner)
   (block out 
     (loop 
-     (cond ((null states) (return-from out +fail+))
-	   ((funcall goal-p (first states))
-	    (return-from out (first states)))
-	   (t (setf states
-		    (funcall combiner
-			     (funcall successors (first states))
-			     (rest states))))))))
+       (cond ((null states) (return-from out +fail+))
+	     ((funcall goal-p (first states))
+	      (return-from out (first states)))
+	     (t (setf states
+		      (funcall combiner
+			       (funcall successors (first states))
+			       (rest states))))))))
 
 (defun tree-search (states goal-p successors combiner)
   "Find a state that satisfies goal-p.  Start with states,

--- a/paip/test-pattern.lisp
+++ b/paip/test-pattern.lisp
@@ -1,6 +1,11 @@
-(in package test-search)
+
+(in-package test-pattern)
 
 (deftest test-pat-match ()
  (check
   (equal (pat-match '(x = (?is ?n numberp)) '(x = 34)) '((?n . 34)))
   (equal (pat-match '(?x (?or < = >) ?y) '(3 < 4)) '((?y . 4) (?x . 3)))))
+
+(deftest test-pattern ()
+  (combine-results
+    (test-pat-match)))

--- a/paip/test-search.lisp
+++ b/paip/test-search.lisp
@@ -1,0 +1,17 @@
+
+(in-package test-search)
+
+(deftest test-depth-first-search ()
+  (check
+    (equal (depth-first-search 1 (is 16) (finite-binary-tree 15)) nil)
+    (equal (depth-first-search 1 (is 13) (finite-binary-tree 15)) 13)
+    (equal (depth-first-search 1 (is 12) (finite-binary-tree 15)) 12)))
+
+(deftest test-breadth-first-search ()
+  (check
+    (equal (breadth-first-search 1 (is 12) 'binary-tree) 12)))
+
+(deftest test-search ()
+  (combine-results
+    (test-depth-first-search)
+    (test-breadth-first-search)))

--- a/paip/test-search.lisp
+++ b/paip/test-search.lisp
@@ -11,7 +11,12 @@
   (check
     (equal (breadth-first-search 1 (is 12) 'binary-tree) 12)))
 
+(deftest test-best-first-search ()
+  (check
+    (equal (best-first-search 1 (is 12) 'binary-tree (diff 12)) 12)))
+
 (deftest test-search ()
   (combine-results
     (test-depth-first-search)
-    (test-breadth-first-search)))
+    (test-breadth-first-search)
+    (test-best-first-search)))

--- a/paip/testcases-framework.lisp
+++ b/paip/testcases-framework.lisp
@@ -1,5 +1,5 @@
 
-(in-package testcases)
+(in-package testcases-framework)
 
 (defvar *test-name* nil)
 
@@ -25,3 +25,8 @@
   `(defun ,name ,parameters
      (let ((*test-name* (append *test-name* (list ',name))))
        ,@body)))
+
+(deftest test-paip ()
+  (combine-results
+    (test-search::test-search)
+    (test-pattern::test-pattern)))

--- a/paip/testcases.lisp
+++ b/paip/testcases.lisp
@@ -1,0 +1,27 @@
+
+(in-package testcases)
+
+(defvar *test-name* nil)
+
+(defun report-result (result form)
+  (format t "~:[FAIL~;pass~] ... ~a: ~a~%" result *test-name* form)
+  result)
+
+(defmacro check (&body forms)
+  `(combine-results
+    ,@(loop for f in forms collect `(report-result ,f ',f))))
+
+(defmacro with-gensyms (syms &body body)
+  `(let ,(loop for s in syms collect `(,s (gensym)))
+    ,@body))
+
+(defmacro combine-results (&body forms)
+  (with-gensyms (result)
+    `(let ((,result t))
+      ,@(loop for f in forms collect `(unless ,f (setf ,result nil)))
+      ,result)))
+
+(defmacro deftest (name parameters &body body)
+  `(defun ,name ,parameters
+     (let ((*test-name* (append *test-name* (list ',name))))
+       ,@body)))


### PR DESCRIPTION
Uma Framework criada, baseada em http://www.gigamonkeys.com/book/practical-building-a-unit-test-framework.html  . Adicionados alguns poucos casos de teste para algumas funções do search.lisp, e para o pat-match. Para usar:
```
(in-package testcases-framework)
(test-paip)
```
Resultado:
```
pass ... (TEST-PAIP TEST-SEARCH TEST-DEPTH-FIRST-SEARCH): (EQUAL
                                                           (DEPTH-FIRST-SEARCH
                                                            1 (IS 16)
                                                            (FINITE-BINARY-TREE
                                                             15))
                                                           NIL)
pass ... (TEST-PAIP TEST-SEARCH TEST-DEPTH-FIRST-SEARCH): (EQUAL
                                                           (DEPTH-FIRST-SEARCH
                                                            1 (IS 13)
                                                            (FINITE-BINARY-TREE
                                                             15))
                                                           13)
pass ... (TEST-PAIP TEST-SEARCH TEST-DEPTH-FIRST-SEARCH): (EQUAL
                                                           (DEPTH-FIRST-SEARCH
                                                            1 (IS 12)
                                                            (FINITE-BINARY-TREE
                                                             15))
                                                           12)
pass ... (TEST-PAIP TEST-SEARCH TEST-BREADTH-FIRST-SEARCH): (EQUAL
                                                             (BREADTH-FIRST-SEARCH
                                                              1 (IS 12)
                                                              'BINARY-TREE)
                                                             12)
pass ... (TEST-PAIP TEST-SEARCH TEST-BEST-FIRST-SEARCH): (EQUAL
                                                          (BEST-FIRST-SEARCH
                                                           1 (IS 12)
                                                           'BINARY-TREE
                                                           (DIFF 12))
                                                          12)
FAIL ... (TEST-PAIP TEST-PATTERN TEST-PAT-MATCH): (EQUAL
                                                   (PAT-MATCH
                                                    '(X =
                                                      (?IS ?N NUMBERP))
                                                    '(X = 34))
                                                   '((?N . 34)))
FAIL ... (TEST-PAIP TEST-PATTERN TEST-PAT-MATCH): (EQUAL
                                                   (PAT-MATCH
                                                    '(?X (?OR < = >) ?Y)
                                                    '(3 < 4))
                                                   '((?Y . 4) (?X . 3)))
```

E a função retorna o valor Nil, pois como podemos ver ela falha em dois casos de teste da função pat-match.

Além disso, é possível testar funções específicas... Por exemplo, para testar o pat-match, basta:
```
(in-package test-pattern)
(test-pat-match)
```
Resultado:
```
FAIL ... (TEST-PAT-MATCH): (EQUAL
                            (PAT-MATCH '(X = (?IS ?N NUMBERP)) '(X = 34))
                            '((?N . 34)))
FAIL ... (TEST-PAT-MATCH): (EQUAL
                            (PAT-MATCH '(?X (?OR < = >) ?Y) '(3 < 4))
                            '((?Y . 4) (?X . 3)))

```
E retorna NIL.

