### PR TITLE
Aplica Search no Problema GPS - Seção 6.5

### DIFF
--- a/paip/gps-2.lisp
+++ b/paip/gps-2.lisp
@@ -10,6 +10,9 @@
   "An operation"
   (action nil) (preconds nil) (add-list nil) (del-list nil))
 
+(defun action-p (x)
+  "Is x something that is (start) or (executing ...)?"
+  (or (equal x '(start)) (executing-p x)))
 
 (defun executing-p (x)
   "Is x of the form: (executing ...) ?"

--- a/paip/gps-blocks.lisp
+++ b/paip/gps-blocks.lisp
@@ -1,0 +1,32 @@
+
+(in-package :gps-test)
+
+(defun symbol-pattern (x)
+  (find-symbol (symbol-name x) :pattern))
+
+(defun make-block-ops (blocks)
+  (let ((ops nil))
+    (dolist (a blocks)
+      (dolist (b blocks)
+        (unless (equal a b)
+          (dolist (c blocks)
+            (unless (or (equal c a) (equal c b))
+              (push (move-op a b c) ops)))
+          (push (move-op a 'table b) ops)
+          (push (move-op a b 'table) ops))))
+    ops))
+
+(defun move-op (a b c)
+  "Make an operator to move A from B to C."
+  (op `(move ,a from ,b to ,c)
+      :preconds `((space on ,a) (space on ,c) (,a on ,b))
+      :add-list (move-ons a b c)
+      :del-list (move-ons a c b)))
+
+(defun move-ons (a b c)
+  (if (eq b 'table)
+      `((,a on ,c))
+      `((,a on ,c) (space on ,b))))
+
+(use (make-block-ops '(a b c)))
+(setf start '((c on a) (a on table) (b on table) (space on c) (space on b) (space on table)))

--- a/paip/gps-monkey.lisp
+++ b/paip/gps-monkey.lisp
@@ -1,0 +1,29 @@
+
+(in-package :gps-test)
+
+(defparameter *banana-ops*
+  (list
+    (op 'climb-on-chair
+        :preconds '(chair-at-middle-room at-middle-room on-floor)
+        :add-list '(at-bananas on-chair)
+        :del-list '(at-middle-room on-floor))
+    (op 'push-chair-from-door-to-middle-room
+        :preconds '(chair-at-door at-door)
+        :add-list '(chair-at-middle-room at-middle-room)
+        :del-list '(chair-at-door at-door))
+    (op 'walk-from-door-to-middle-room
+        :preconds '(at-door on-floor)
+        :add-list '(at-middle-room)
+        :del-list '(at-door))
+    (op 'grasp-bananas
+        :preconds '(at-bananas empty-handed)
+        :add-list '(has-bananas)
+        :del-list '(empty-handed))
+    (op 'drop-ball
+        :preconds '(has-ball)
+        :add-list '(empty-handed)
+        :del-list '(has-ball))
+    (op 'eat-bananas
+        :preconds '(has-bananas)
+        :add-list '(empty-handed not-hungry)
+        :del-list '(has-bananas hungry))))

--- a/paip/packages.lisp
+++ b/paip/packages.lisp
@@ -40,10 +40,34 @@
    #:op-preconds
    #:op-action
    #:gps
-   #:use))
+   #:use
+   #:action-p
+   #:*ops*
+   #:member-equal))
+
+(defpackage :search
+  (:use :cl :utils)
+  (:export
+   #:tree-search
+   #:depth-first-search
+   #:binary-tree
+   #:is
+   #:prepend
+   #:breadth-first-search
+   #:finite-binary-tree
+   #:diff
+   #:best-first-search
+   #:beam-search))
+
+(defpackage :search-gps
+  (:use :utils :cl :gps-2 :search)
+  (:export
+   #:search-gps))
 
 (defpackage :gps-test
-  (:use :utils :cl :gps-2))
+  (:use :utils :cl :gps-2 :search-gps)
+  (:export
+   #:make-block-ops))
 
 (defpackage :pattern
   (:use :cl :utils)
@@ -69,19 +93,6 @@
 (defpackage :eliza-test
   (:use :cl :utils :eliza :pattern))
 
-(defpackage :search
-  (:use :cl :utils)
-  (:export
-   #:tree-search
-   #:depth-first-search
-   #:binary-tree
-   #:is
-   #:prepend
-   #:breadth-first-search
-   #:finite-binary-tree
-   #:diff
-   #:best-first-search))
-
 (defpackage :testcases-framework
   (:use :utils :cl :search :eliza :eliza-test)
   (:export
@@ -92,10 +103,11 @@
    #:report-result))
 
 (defpackage :test-search
-  (:use :utils :cl :search :testcases-framework))
+  (:use :utils :cl :search :testcases-framework :search-gps :gps-2 :gps-test))
   
 (defpackage :test-pattern
   (:use :utils :cl :pattern :testcases-framework))
 
 (defpackage :student
   (:use :utils :cl :pattern))
+

--- a/paip/paip.asd
+++ b/paip/paip.asd
@@ -22,6 +22,9 @@
 	       (:file "testcases-framework"   :depends-on ("utils"))
 	       (:file "test-search"           :depends-on ("search" "testcases-framework"))
 	       (:file "test-pattern"          :depends-on ("pattern" "testcases-framework"))
+	       (:file "gps-blocks"            :depends-on ("gps-2"))
+	       (:file "gps-monkey"            :depends-on ("gps-2"))
+	       (:file "search-gps"            :depends-on ("gps-2" "search"))
 	       (:file "student"               :depends-on ("pattern"))))
 
 

--- a/paip/search-gps.lisp
+++ b/paip/search-gps.lisp
@@ -1,0 +1,35 @@
+(in-package search-gps)
+
+(defun search-gps (start goal &optional (beam-width 10))
+  "Search for a sequence of operators leading to a goal."
+  (find-all-if
+    #'action-p
+    (beam-search
+      (cons '(start) start)
+      #'(lambda (state) (subsetp goal state :test #'equal))
+      #'gps-successors
+      #'(lambda (state)
+          (+ (count-if #'action-p state)
+             (count-if #'(lambda (con)
+                           (not (member-equal con state)))
+                       goal)))
+      beam-width)))
+
+(defun gps-successors (state)
+  "Return a list of states reachable from this one using ops."
+  (mapcar
+    #'(lambda (op)
+        (append
+          (remove-if #'(lambda (x)
+                         (member-equal x (op-del-list op)))
+                     state)
+          (op-add-list op)))
+    (applicable-ops state)))
+
+(defun applicable-ops (state)
+  "Return a list of all ops that are applicable now."
+  (find-all-if
+    #'(lambda (op)
+        (subsetp (op-preconds op) state :test #'equal))
+    *ops*))
+

--- a/paip/test-search.lisp
+++ b/paip/test-search.lisp
@@ -20,6 +20,13 @@
     (equal '(125 255 15)
 	   (search::search-n 1 3 (lambda (n) (equal 0 (mod n 5))) #'binary-tree (search::price-is-right 300) 5))))
 
+;;(deftest test-search-gps ()
+;;  (check
+;;    (equal (search-gps '((c on a) (a on table) (b on table) (space on c) (space on b) (space on table))
+;;		       '((b on c) (a on b))) '((GPS-2::EXECUTING (MOVE C FROM A TO TABLE))
+;;					       (GPS-2::EXECUTING (MOVE B FROM TABLE TO C))
+;;					       (GPS-2::EXECUTING (MOVE A FROM TABLE TO B))))))
+
 (deftest test-search ()
   (combine-results
     (test-depth-first-search)


### PR DESCRIPTION
Aplica Search no problema GPS, conforme 6.5. Além disso, adicionamos o código referente à seção 4.12 e 4.14. Tentou-se usar o test-search para testar a nova função, porém ainda temos problemas simbólicos a resolver. Para analisar melhor isso, vá ao package test-search e veja o valor da variável *ops*. Por enquanto, o teste foi feito da seguinte forma:

```
(in-package :gps-test)
```

```
(search-gps start '((a on b) (b on c)))
```
E o resultado obtido é:
```
((GPS-2::EXECUTING (MOVE C FROM A TO TABLE))
 (GPS-2::EXECUTING (MOVE B FROM TABLE TO C))
 (GPS-2::EXECUTING (MOVE A FROM TABLE TO B)))
```

Conforme o esperado.
