### PR TITLE
Novos testes para a pat-match e mudança sutil da segment-match

### DIFF
--- a/paip/packages.lisp
+++ b/paip/packages.lisp
@@ -18,8 +18,7 @@
    #:string->list
    #:eql-by-name-if-symbol
    #:interactive-interpreter
-   #:prompt-generator
-   #:rule-based-translator))
+   #:prompt-generator))
 
 (defpackage :chapter-1
   (:use :utils :cl)
@@ -93,7 +92,8 @@
    #:pat-match
    #:pat-match-abbrev
    #:segment-pattern-p
-   #:expand-pat-match-abbrev))
+   #:expand-pat-match-abbrev
+   #:rule-based-translator))
 
 (defpackage :pattern-test
   (:use :cl :utils :pattern :tests-framework))

--- a/paip/pattern-test.lisp
+++ b/paip/pattern-test.lisp
@@ -4,7 +4,22 @@
 (deftest test-pat-match ()
  (check
   (equal (nth-value 1 (pat-match '(x = (?is ?n numberp)) '(x = 34))) '((?n . 34)))
-  (equal (nth-value 1 (pat-match '(?x (?or < = >) ?y) '(3 < 4))) '((?y . 4) (?x . 3)))))
+  (equal (nth-value 1 (pat-match '(?x (?or < = >) ?y) '(3 < 4))) '((?y . 4) (?x . 3)))
+  (multiple-value-bind (res binding)
+      (pat-match '(teste ?x de (?* ?Y) funcionalidades da (?or pat-match segment-match))
+		 '(teste parcial de algumas das funcionalidades da pat-match))
+    (and res (equal binding '((?Y algumas das) (?X . parcial)))))
+  (multiple-value-bind (res binding)
+      (pat-match '(a (?* ?X) c d) '(a b c b c d))
+    (and res (equal binding '((?X b c b)))))
+  (multiple-value-bind (res binding)
+      (pat-match '(teste de erro (?* ?X) segment match)
+		 '(teste de erro da função segment-match))
+    (equal `(,res ,binding) '(nil nil)))
+  (multiple-value-bind (res binding)
+      (pat-match '(teste da ultima (?* ?X) função)
+		 '(teste da última saída possível da segment-match))
+    (equal `(,res ,binding) '(nil nil)))))
 
 (deftest test-pattern ()
   (combine-results

--- a/paip/pattern.lisp
+++ b/paip/pattern.lisp
@@ -89,15 +89,16 @@
         (let ((pos (position (first pat) input
                              :start start :test #'equal)))
           (if (null pos)
-              +fail+
-              (let ((b2 (nth-value 1 (pat-match pat (subseq input pos)
-				   (nth-value 1 (match-variable var (subseq input 0 pos)
-						   bindings))))))
-                ;; If this match failed, try another longer one
-                (if (eq b2 +fail+)
-                    (segment-match pattern input bindings (+ pos 1))
-                    (values t b2))))))))
-        
+	      (values nil nil)
+	      (multiple-value-bind (res b2)
+		  (pat-match pat (subseq input pos)
+			     (nth-value 1 (match-variable var (subseq input 0 pos)
+							  bindings)))
+		;; If this match failed, try another longer one
+		(if (not res)
+		    (segment-match pattern input bindings (+ pos 1))
+		    (values t b2))))))))
+
 (defun segment-pattern-p (pattern)
   (and (consp pattern) (consp (first pattern))
     (symbolp (first (first pattern)))

--- a/paip/pattern.lisp
+++ b/paip/pattern.lisp
@@ -192,3 +192,14 @@
     ((atom pat) pat)
     (t (cons (expand-pat-match-abbrev (first pat))
 	     (expand-pat-match-abbrev (rest pat))))))
+
+(defun rule-based-translator (input rules &key (matcher #'pattern::pat-match)
+				    (rule-if #'first)
+				    (rule-then #'rest)
+				    (action #'sublis))
+  (some #'(lambda (rule)
+	    (multiple-value-bind (result bindings)
+		(funcall matcher (funcall rule-if rule) input)
+	      (if result
+		  (funcall action bindings (funcall rule-then rule)))))
+	rules))

--- a/paip/student.lisp
+++ b/paip/student.lisp
@@ -202,3 +202,20 @@
 	      (if (binary-exp-p exp)
 		  (list (exp-lhs exp) (exp-op exp) (exp-rhs exp))
 		  exp))))
+
+(defun solve-system (e u)
+  ;;  inputs na forma ((= (+ (* a x) (* b y)) m) (= (+ (* c x) (* d y)) n))
+  (multiple-value-bind (res binding)
+      (pat-match `((= (+ (* ?A ,(first u)) (* ?B ,(second u))) ?M)
+		   (= (+ (* ?C ,(first u)) (* ?D ,(second u))) ?N))
+		 e)
+  (if res
+      (let ((a (cdr (assoc '?A binding)))
+	    (b (cdr (assoc '?B binding)))
+	    (c (cdr (assoc '?C binding)))
+	    (d (cdr (assoc '?D binding)))
+	    (m (cdr (assoc '?M binding)))
+	    (n (cdr (assoc '?N binding))))
+	(let ((y-f (eval (/ (- (* n a) (* m c)) (- (* d a) (* b c))))))
+	(solve (subst y-f 'y (list (car e))) `((y . ,y-f))))))))
+

--- a/paip/utils.lisp
+++ b/paip/utils.lisp
@@ -203,15 +203,3 @@
 (defun prompt-generator (&optional (num 0) (ctl-string "[~d] "))
   "Return a function that prints prompts like [1], [2], etc."
   #'(lambda () (format t ctl-string (incf num))))
-
-
-(defun rule-based-translator (input rules &key (matcher #'pattern::pat-match)
-				    (rule-if #'first)
-				    (rule-then #'rest)
-				    (action #'sublis))
-  (some #'(lambda (rule)
-	    (multiple-value-bind (result bindings)
-		(funcall matcher (funcall rule-if rule) input)
-	      (if result
-		  (funcall action bindings (funcall rule-then rule)))))
-	rules))


### PR DESCRIPTION
Mudanças na ```segment-match```: 

1) A saída de erro estava devolvendo apenas 'nil' quando deveria devolver 'nil nil'. 

2) Mudança do teste do último IF. O teste para erro era se a saída dos bindings era igual a NIL, com a mudança o teste será a primeira saída (T/NIL). Isso não tem efeito prático, pois essa chamada específica do ```pat-match``` já recebe um valor para bindings e só retornará NIL se der erro, mas por uma questão de coerência e até preciosismo eu achei que valia a mudança.