### PR TITLE
Solução “não elegante” para contornar os problemas e testar o math-symbolic

### DIFF
--- a/paip/math-tests.lisp
+++ b/paip/math-tests.lisp
@@ -1,10 +1,9 @@
-Testes que passaram:
-
+;; Passed tests:
 (equal (simp '(2 + 2)) 4)
 (equal (simp '( x ^ cos pi)) '(1 / x))
+(equal (simp '(5 * 20 + 30 + 7)) 137)
 
-Testes que não passaram:
-
+;; Failed tests:
 (equal (simp '( d ( x + x ) / d x )) 2)
 (equal (simp '(d (a * x ^ 2 + b * x + c) / d x)) 2)
 (equal (simp '( d ( ( a * x ^ 2 + b * x + c) / x) / d x)) '( ( ( ( A * (X 2 ) ) + ( ( B * X I + C)) - (X * ( ( 2 * (A * XI) + B ) ) )))))
@@ -12,3 +11,8 @@ Testes que não passaram:
 (equal (simp '(d (3 * x + (cos x) / x) / d x)) '((((cos x) - (x * (- (sin x))) / (x ^ 2)) + 3)))
 (equal (simp '(d (3 * x ^ 2 + 2 * x + 1) / d x)) '((6 * x) + 2))
 (equal (simp '(sin (x + x) ^ 2 + cos(d x ^ 2 / d x) ^ 2)) 1)
+(equal (simp '( l o g ( x + x ) - l o g x )) '(log 2))
+(equal (simp '(d ((cos x) / x) / d x)) '((((COS X) - ( X * ( - (SIN X ) ) ) ) / ( X ^ 2))))
+(equal (simp '(sin ( x + x ) * sin (d x ^ 2 / d x) + cos(2 * x ) * cos(x * d 2 * y / d y ) )) 1)
+(equal (simp '(y / z * (5 * x - (4 + 1) * X))) 0)
+(equal (simp '(Int x * sin(x ^ 2) d x)) '(1/2 * (- (COS (X ^ 2)))))


### PR DESCRIPTION
(Notem que esta implementação ocorreu antes da atualização de 09/12 do variable-p pelo @arademaker).

À luz dos desafios apresentados pela integração do math-symbolic com os demais pacotes, temos discutido bastante sobre a implementação dos testes necessários ao Cap8. De fato, na última semana, seis pessoas envolveram diretamente, em diferentes graus, nas discussões e tentativas de solucionar os diversos desafios apresentados (@caioramalhofgv, @Fellipe293, @kalinest, @lucaslico, @rafaelbetatester, @rbarsotti). Além disso, surgiram discussões complementares muito interessantes sobre o variable-p com @talesrands e @arademaker.

Concentramos nossas ações utilizando os pacotes do nosso repositório (ex. pattern), porém a cada tentativa de rodar o math-symbolic para efetuar seus testes, ou apareciam novos problemas, ou não entendíamos os problemas recorrentes.

Após diversas(!!) tentativas frustradas, decidimos explorar uma solução alternativa: modularizar o problema. Ou seja, analisar o projeto math-symbolic isoladamente e então, com ele rodando OK, encaixá-lo no projeto maior (como peças de Lego). As motivações para esta decisão foram:
a) Não sabemos com certeza se os problemas vêm do math-symbolic, de outro(s) pacote(s), ou a interação entre eles;
b) Não podemos ficar com o Cap8 sem os testes. 
 
Plano de Ação:
1°) Precisávamos de uma versão do pattern sem as alterações e melhorias implementadas ao longo do curso, da mesma forma apresentada no Livro PAIP. Tomamos como base o site do Peter Norvig (http://norvig.com/paip/patmatch.lisp) e o repositório https://github.com/flavioc/paip/blob/master/pattern-match.lisp 

Para o math-symbolic, voltamos para a linha do Livro PAIP e mantivemos o math-rules dentro do math-symbolic como no Cap8. E o math-symbolic só depende do pattern, a qual pegamos uma versão “crua”.

2°) Compilamos a versão “crua” do arquivo pattern (que renomeamos de math-pattern) no Emacs. Depois compilamos o arquivo math-symbolic. Com isso, identificamos alguns erros que corrigimos (ex. parênteses que impediam algumas funções rodarem corretamente). Ambos, ao serem compilados no Emacs na sequência, estavam carregando sem erros de compilação e o math-symbolic funcionando.

3°) Para efetuarmos os testes, precisávamos montar um pacote “math” isolado dos demais pacotes do repositório (i.e. math-paip.asd, math-package.lisp, math-pattern.lisp, math-symbolic.lisp). Se tudo desse certo, estaríamos preparados para reinserir o módulo “math” em nosso repositório e reiniciar as investigações dos pontos críticos da “fusão” dos projetos (assumindo que os demais pacotes estivessem realmente OK também).

Entretanto, esta fase falhou. Nosso pacote compilava até certo ponto e dava problemas que não conseguimos solucionar. Após muita discussão e investigações sobre onde poderia estar o problema, decidimos dar uma passo atrás à 1ª fase com o objetivo de resolver a implementação dos testes. 

4°) Já que perdemos a solução de pacote, como uma solução alternativa “não elegante”, porém prática, foi colocar os 2 códigos (math-pattern e math-symbolic) em um único arquivo: math-combo. 

Com isto, foi possível rodar o código e efetuar os testes (math-tests). Embora alguns testes ainda precisem ser aprimorados, foi um grande avanço e um ótimo trabalho em equipe. 

Sugestões e contribuições adicionais são muito bem-vindas.
Abraço,
Caio